### PR TITLE
fix(units): Remove afterload function and add items loading in services

### DIFF
--- a/src/army-list/army-list.controller.ts
+++ b/src/army-list/army-list.controller.ts
@@ -111,7 +111,7 @@ export class ArmyListController {
     async update(@Request() req,
         @Param("id") id: string,
         @Body() { name, armyId, valuePoints, isShared, units, isFavorite }: ArmyListParameterDTO): Promise<void> {
-        let list: ArmyList = await this.armyListService.findOneById(id, { loadUnits: true});
+        let list: ArmyList = await this.armyListService.findOneById(id, { loadAll: true});
 
         if (list === null) {
             throw new NotFoundException();

--- a/src/army/army.controller.ts
+++ b/src/army/army.controller.ts
@@ -24,7 +24,7 @@ export class ArmyController {
     @HttpCode(HttpStatus.OK)
     async get(@Param("id") id: number): Promise<ArmyDTO> {
         try {
-            let army: Army = await this.armyService.findOneById(id);
+            let army: Army = await this.armyService.findOneById(id, { loadUnits: true });
             if (army === null) {
                 throw new NotFoundException();
             }

--- a/src/army/army.entity.ts
+++ b/src/army/army.entity.ts
@@ -76,8 +76,6 @@ export class Army {
             async (value: number): Promise<Equipment> => await datasource.getRepository(Equipment).findOneBy({ id: value })));
         this.specialRules = await Promise.all(this.equipmentIds.map(
             async (value: number): Promise<SpecialRule> => await datasource.getRepository(SpecialRule).findOneBy({ id: value })));
-        this.units = await Promise.all(this.unitIds.map(
-            async (value: number): Promise<Unit> => await datasource.getRepository(Unit).findOneBy({ id: value })));
         await datasource.destroy();
     }
 }

--- a/src/army/army.service.ts
+++ b/src/army/army.service.ts
@@ -2,12 +2,19 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Army } from "./army.entity";
 import { Repository } from "typeorm";
+import { UnitService } from "@army/unit/unit.service";
+import { Unit } from "@army/unit/unit.entity";
+
+export type ArmyServiceServiceOptions = {
+    loadUnits?: boolean;
+}
 
 @Injectable()
 export class ArmyService {
     constructor(
         @InjectRepository(Army)
         private repository: Repository<Army>,
+        private unitService: UnitService
     ) {}
 
     async getAll(): Promise<Army[]> {
@@ -18,7 +25,20 @@ export class ArmyService {
         return query.getMany();
     }
 
-    async findOneById(id: number): Promise<Army> {
-        return this.repository.findOneBy([{ id: id }]);
+    async findOneById(id: number, options?: ArmyServiceServiceOptions): Promise<Army> {
+        let army: Army = await this.repository.findOneBy([{ id: id }]);
+
+        if (options?.loadUnits === true) {
+            army = await this._loadUnits(army);
+        }
+        return army;
+    }
+
+    private async _loadUnits(army: Army): Promise<Army> {
+        if (army !== null && army !== undefined) {
+            army.units = await Promise.all(army.unitIds.map(
+                async (id: number): Promise<Unit> => this.unitService.findOneById(id)));
+        }
+        return army;
     }
 }

--- a/src/army/unit/option/unit-option.service.ts
+++ b/src/army/unit/option/unit-option.service.ts
@@ -14,6 +14,10 @@ class UnitOptionService {
     async findOneById(id: number): Promise<UnitOption> {
         return this.repository.findOneBy([{ id: id }]);
     }
+
+    async findByIds(ids: number[]): Promise<UnitOption[]> {
+        return Promise.all(ids.map(async (id: number): Promise<UnitOption> => this.repository.findOneBy([{ id: id }])));
+    }
 }
 
 export default UnitOptionService;

--- a/src/army/unit/troop/equipment/equipment-unit-troop.service.ts
+++ b/src/army/unit/troop/equipment/equipment-unit-troop.service.ts
@@ -14,6 +14,10 @@ class EquipmentUnitTroopService {
     async findOneById(id: number): Promise<EquipmentUnitTroop> {
         return this.repository.findOneBy([{ id: id }]);
     }
+
+    async findByIds(ids: number[]): Promise<EquipmentUnitTroop[]> {
+        return Promise.all(ids.map(async (id: number): Promise<EquipmentUnitTroop> => this.repository.findOneBy([{ id: id }])));
+    }
 }
 
 export default EquipmentUnitTroopService;

--- a/src/army/unit/troop/special-rule/special-rule-unit-troop.service.ts
+++ b/src/army/unit/troop/special-rule/special-rule-unit-troop.service.ts
@@ -14,6 +14,10 @@ class SpecialRuleUnitTroopService {
     async findOneById(id: number): Promise<SpecialRuleUnitTroop> {
         return this.repository.findOneBy([{ id: id }]);
     }
+
+    async findByIds(ids: number[]): Promise<SpecialRuleUnitTroop[]> {
+        return Promise.all(ids.map(async (id: number): Promise<SpecialRuleUnitTroop> => this.repository.findOneBy([{ id: id }])));
+    }
 }
 
 export default SpecialRuleUnitTroopService;

--- a/src/army/unit/unit.entity.ts
+++ b/src/army/unit/unit.entity.ts
@@ -1,10 +1,9 @@
-import { Entity, PrimaryColumn, Column, AfterLoad } from "typeorm";
+import { Entity, PrimaryColumn, Column } from "typeorm";
 
 import { Troop } from "./troop/troop.entity";
 import { SpecialRuleUnitTroop } from "./troop/special-rule/special-rule-unit-troop.entity";
 import { EquipmentUnitTroop } from "./troop/equipment/equipment-unit-troop.entity";
 import { UnitOption } from "./option/unit-option.entity";
-import { ProphecyDatasource } from "@database/prophecy.datasource";
 
 export class UnitCharacteristic {
     public type: string;
@@ -89,19 +88,4 @@ export class Unit {
     public equipmentUnitTroops: EquipmentUnitTroop[] = [];
     public unitOptions: UnitOption[] = [];
 
-    @AfterLoad()
-    private async load() {
-        let datasource: ProphecyDatasource = new ProphecyDatasource();
-
-        await datasource.initialize();
-        for (const id of this.troopIds)
-            this.troops.push(await datasource.getRepository(Troop).findOneBy({ id: id }));
-        for (const id of this.specialRuleUnitTroopIds)
-            this.specialRuleUnitTroops.push(await datasource.getRepository(SpecialRuleUnitTroop).findOneBy({ id: id }));
-        for (const id of this.equipmentUnitTroopIds)
-            this.equipmentUnitTroops.push(await datasource.getRepository(EquipmentUnitTroop).findOneBy({ id: id }));
-        for (const id of this.unitOptionIds)
-            this.unitOptions.push(await datasource.getRepository(UnitOption).findOneBy({ id: id }));
-        await datasource.destroy();
-    }
 }

--- a/src/army/unit/unit.module.ts
+++ b/src/army/unit/unit.module.ts
@@ -4,15 +4,24 @@ import { Unit } from "@army/unit/unit.entity";
 import { UnitService } from "@army/unit/unit.service";
 import { Troop } from "@army/unit/troop/troop.entity";
 import { TroopService } from "@army/unit/troop/troop.service";
+import { SpecialRuleUnitTroop } from "@army/unit/troop/special-rule/special-rule-unit-troop.entity";
+import { EquipmentUnitTroop } from "@army/unit/troop/equipment/equipment-unit-troop.entity";
+import { UnitOption } from "@army/unit/option/unit-option.entity";
+import SpecialRuleUnitTroopService from "@army/unit/troop/special-rule/special-rule-unit-troop.service";
+import EquipmentUnitTroopService from "@army/unit/troop/equipment/equipment-unit-troop.service";
+import UnitOptionService from "@army/unit/option/unit-option.service";
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([
             Unit,
-            Troop
+            Troop,
+            SpecialRuleUnitTroop,
+            EquipmentUnitTroop,
+            UnitOption
         ])
     ],
-    providers: [UnitService, TroopService],
-    exports: [UnitService, TroopService]
+    providers: [UnitService, TroopService, SpecialRuleUnitTroopService, EquipmentUnitTroopService, UnitOptionService],
+    exports: [UnitService, TroopService, SpecialRuleUnitTroopService, EquipmentUnitTroopService, UnitOptionService]
 })
 export class UnitModule {}

--- a/src/army/unit/unit.service.ts
+++ b/src/army/unit/unit.service.ts
@@ -2,15 +2,31 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Unit } from "@army/unit/unit.entity";
 import { Repository } from "typeorm";
+import { TroopService } from "@army/unit/troop/troop.service";
+import SpecialRuleUnitTroopService from "@army/unit/troop/special-rule/special-rule-unit-troop.service";
+import EquipmentUnitTroopService from "@army/unit/troop/equipment/equipment-unit-troop.service";
+import UnitOptionService from "@army/unit/option/unit-option.service";
 
 @Injectable()
 export class UnitService {
     constructor(
         @InjectRepository(Unit)
-        private readonly repository: Repository<Unit>
+        private readonly unitRepository: Repository<Unit>,
+        private readonly troopService: TroopService,
+        private readonly ruleService: SpecialRuleUnitTroopService,
+        private readonly equipmentService: EquipmentUnitTroopService,
+        private readonly optionService: UnitOptionService
     ) {}
 
     async findOneById(id: number): Promise<Unit> { // TODO: add options
-        return this.repository.findOneBy([{ id: id }]);
+        const unit: Unit = await this.unitRepository.findOneBy([{ id: id }]);
+
+        if (unit !== null && unit !== undefined) {
+            unit.troops = await this.troopService.findByIds(unit.troopIds);
+            unit.specialRuleUnitTroops = await this.ruleService.findByIds(unit.specialRuleUnitTroopIds);
+            unit.equipmentUnitTroops = await this.equipmentService.findByIds(unit.equipmentUnitTroopIds);
+            unit.unitOptions = await this.optionService.findByIds(unit.unitOptionIds);
+        }
+        return unit;
     }
 }

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -7,6 +7,7 @@ import { ArmyList } from "@army-list/army-list.entity";
 import { ArmyListService } from "@army-list/army-list.service";
 import { Profile } from "@profile/profile.entity";
 import { ProfileService } from "@profile/profile.service";
+import { UnitModule } from "@army/unit/unit.module";
 
 /**
  * @class GameModule
@@ -18,7 +19,8 @@ import { ProfileService } from "@profile/profile.service";
             Game,
             ArmyList,
             Profile
-        ])
+        ]),
+        UnitModule
     ],
     providers: [
         GameService,

--- a/tests/api/game/delete.spec.ts
+++ b/tests/api/game/delete.spec.ts
@@ -90,7 +90,6 @@ describe("Games route", () => {
             .set("Authorization", `Bearer ${ownerToken}`)
             .then(res => res.body);
 
-        // console.log(games)
         games.map(g => expect(g.id !== gameId));
 
     });

--- a/tests/api/prophecy/units/create.spec.ts
+++ b/tests/api/prophecy/units/create.spec.ts
@@ -7,6 +7,8 @@ import * as request from "supertest";
 import { ArmyListUnitCredentialsDTO } from "../../../../src/army-list/army-list-unit/army-list-unit-credentials.dto";
 import { PROPHEC_UNIT_ATTACKING_REGIMENT, PROPHECY_UNIT_DEFENDING_REGIMENT, PROPHECY_UNIT_REQUEST } from "../../../fixtures/prophecy/prophecy";
 
+jest.setTimeout(20000);
+
 const USERNAME = faker.internet.userName();
 const EMAIL = faker.internet.email();
 const PASSWORD = faker.internet.password();

--- a/tests/api/prophecy/units/delete.spec.ts
+++ b/tests/api/prophecy/units/delete.spec.ts
@@ -6,6 +6,8 @@ import { TestsHelper } from "../../../tests.helper";
 import * as request from "supertest";
 import { PROPHECY_UNIT_REQUEST } from "../../../fixtures/prophecy/prophecy";
 
+jest.setTimeout(20000);
+
 let app: INestApplication;
 let token: string;
 let token1: string;


### PR DESCRIPTION
## Problem
There was an after load function in unit entity that might cause `Too many clients already` errors on multiple army lists requests

## Changes
Moved the units items loading in different services
